### PR TITLE
Footer paragraph fix

### DIFF
--- a/style.css
+++ b/style.css
@@ -126,7 +126,7 @@
     margin: auto;
     color: #473a43;
     font-size: 16px;
-    width: 400px;
+    max-width: 400px;
     margin-top: 8px;
   }
   .events-wrapper::before {


### PR DESCRIPTION
Fixes the footer paragraph by clamping its width, rather than setting it. This centers it on mobile resolutions, because it's allowed to shrink.

This PR concerns issue #5.